### PR TITLE
feat: #24 バックエンドのリント自動化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,5 @@
       }
     }
   },
-  "postCreateCommand": "pip install -r /workspace/backend/requirements.txt && mkdir -p /root/.ssh && cp -r /tmp/host-ssh/. /root/.ssh/ && chmod 700 /root/.ssh && find /root/.ssh -type f -exec chmod 600 {} \\; && ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null"
+  "postCreateCommand": "pip install -r /workspace/backend/requirements.txt && pre-commit install && mkdir -p /root/.ssh && cp -r /tmp/host-ssh/. /root/.ssh/ && chmod 700 /root/.ssh && find /root/.ssh -type f -exec chmod 600 {} \\; && ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null"
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^backend/
+      - id: ruff-format
+        files: ^backend/
+
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy backend/app
+        language: system
+        files: ^backend/.*\.py$
+        pass_filenames: false

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 alembic>=1.13.0
 mypy>=1.10.0
+pre-commit>=3.7.0
 ruff>=0.4.0
 annotated-doc==0.0.4
 pymysql>=1.1.0


### PR DESCRIPTION
## 概要

`pre-commit` を導入し、`git commit` 時に ruff・mypy が自動実行されるようにしました。

## 変更内容

- `.pre-commit-config.yaml` を作成
  - ruff（チェック＋自動修正）を `backend/` に適用
  - ruff-format を `backend/` に適用
  - mypy を `backend/app` に適用
- `.devcontainer/devcontainer.json` を更新
  - `postCreateCommand` に `pre-commit install` を追加し、コンテナ作成時にフックを自動登録

## 動作確認

- [x] `pre-commit run --all-files` がすべて Passed になる
- [x] `.py` ファイルを変更して `git commit` すると ruff・mypy が走る
### 確認
```
root@8b2abc53d486:/workspace# git add .
root@8b2abc53d486:/workspace# git commit -m "feat: #24 バックエンドのリント自動化"
ruff.................................................(no files to check)Skipped
ruff-format..........................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
[feature/#24-setup-pre-commit d0453fb] feat: #24 バックエンドのリント自動化
 3 files changed, 20 insertions(+), 1 deletion(-)
 create mode 100644 .pre-commit-config.yaml
```

## 関連イシュー

close #24
