### PR TITLE
Feature/#27 setup devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "HELM Backend",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "backend",
+  "workspaceFolder": "/workspace",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/tmp/host-ssh,type=bind,readonly"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+        "anthropic.claude-code"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "[python]": {
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "pip install -r /workspace/backend/requirements.txt && mkdir -p /root/.ssh && cp -r /tmp/host-ssh/. /root/.ssh/ && chmod 700 /root/.ssh && find /root/.ssh -type f -exec chmod 600 {} \\; && ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null"
+}

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ HELMは、カードの効果テキストをルールベースで分解・数値�
 
 ### 前提条件
 - Docker Desktop または Rancher Desktop がインストールされていること
+- VS Code + [Dev Containers 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) がインストールされていること
 
-### 手順
+### Dev Containers を使った起動（推奨）
 
 **1. リポジトリをクローン**
 ```bash
@@ -48,19 +49,35 @@ git clone https://github.com/GG-highness/HELM.git
 cd HELM
 ```
 
-**2. コンテナを起動**
+**2. VS Code で開く**
 ```bash
-docker compose up --build
+code .
 ```
 
-**3. Alembic の初期設定（初回のみ）**
-```bash
-docker compose exec backend alembic init alembic
-```
+**3. Dev Container で開き直す**
+
+`Ctrl+Shift+P` → `Dev Containers: Reopen in Container`
+
+VS Code が自動的に Docker コンテナをビルドし、backend コンテナに接続します。
 
 **4. マイグレーション実行**
 ```bash
-docker compose exec backend alembic upgrade head
+cd /app && alembic upgrade head
+```
+
+### Dev Containers の構成について
+
+`.devcontainer/devcontainer.json` の設定：
+
+- **接続先コンテナ**: backend（`docker-compose.yml` の `backend` サービス）
+- **workspaceFolder**: `/workspace`（モノレポルート）
+- **理由**: `docker-compose.yml` に `.:/workspace` のボリュームマウントがあるため、Dev Containers がモノレポルートを `/workspace` として認識する。`workspaceFolder` を `/app`（backendのみ）に設定しても `/workspace` が優先されるため、`/workspace` に統一している
+- **効果**: VS Code のエクスプローラーから `frontend/` と `backend/` の両方を編集できる
+
+### Docker Compose のみで起動する場合
+
+```bash
+docker compose up --build
 ```
 
 ### 動作確認

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends openssh-client && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY requirements.txt .

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ convention = "google"
 [tool.mypy]
 python_version = "3.12"
 mypy_path = "."
+exclude = ["alembic/"]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 warn_return_any = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - "8000:8000"
     volumes:
       - ./backend:/app
+      - .:/workspace
     environment:
       DATABASE_URL: mysql+pymysql://helm:helm@db:3306/helm
     depends_on:


### PR DESCRIPTION
## 概要

Dev Containers を導入し、ローカル環境なしで開発できる環境を整備しました。

## 変更内容

- `.devcontainer/devcontainer.json` を作成
  - `docker-compose.yml` の全サービスを参照
  - VSCode の接続先を `backend` コンテナに設定
  - `workspaceFolder` を `/workspace`（モノレポルート）に設定
  - Python / Ruff / mypy / Claude Code 拡張機能を自動インストール
  - Ruff によるフォーマット自動保存を設定
- SSH 認証の設定
  - ホストの `~/.ssh` を `/tmp/host-ssh` に読み取り専用マウント
  - `postCreateCommand` でコンテナ内の `/root/.ssh` にコピーし権限を修正
  - `ssh-keyscan` で GitHub のホスト鍵を自動登録

## 動作確認

- [x] Reopen in Container でコンテナが起動する
- [x] `frontend/` と `backend/` の両方が VSCode エクスプローラーで編集できる
- [x] `git push` が SSH 経由で通る
- [x] ruff & mypy確認
```
root@8b2abc53d486:/workspace# ruff format backend/
8 files left unchanged
root@8b2abc53d486:/workspace# mypy backend/app/
Success: no issues found in 8 source files
```
## 関連イシュー

close #27

